### PR TITLE
Update trait-geotarget-keys.md

### DIFF
--- a/help/using/features/traits/trait-geotarget-keys.md
+++ b/help/using/features/traits/trait-geotarget-keys.md
@@ -24,7 +24,7 @@ For some platform-level keys, you can specify the value yourself. With others, t
 
 ## User Defined Platform-Level Keys {#user-defined-keys}
 
-You specify the value when building traits with these key-value pairs:  
+If you already have or are establishing a process to define & collect key/value pairs, utilize this option. If you want to use keys pre-defined by IP address, continue to the next section. In this case, you specify the value when building traits with these key-value pairs:  
 
 |  Key  | For Targeting  |
 |---|---|


### PR DESCRIPTION
User-defined keys section was unclear, and was misleading customers to believe "d_zx" was a pre-defined dimension for zip code. Further down the page, the actual pre-defined dimension "d_postal_code" is outlined. I just wanted to clarify the documentation that "d_zx" is just an example of a possible user-defined key in this case. Please feel free to re-word or alter my changes in anyway to grant more clarity. Contact me at curtiso@adobe.com with any questions- thanks!