### PR TITLE
Update cdf-files.md

### DIFF
--- a/help/using/features/cdf-files.md
+++ b/help/using/features/cdf-files.md
@@ -139,6 +139,7 @@ Lists and defines the data structure of a [!UICONTROL CDF] file. This includes d
       <li id="li_B9DA15DCB6A445D781B8753C1C4262B0">Ctrl + a (ASCII <code> 001</code> or <code> ^A</code>) separates data in individual fields with a non-printing space indicator. </li> 
       <li id="li_E68D0CC065B34AC9AF91F166CAA2A67C">Ctrl + b (ASCII <code> 002</code> or <code> ^B</code>) separates data an array and request parameters. </li> 
       <li id="li_6C32D927FEF04CDE9887374E8C2688E7">Ctrl + c (ASCII <code> 003</code> or <code> ^C</code>) defines key-value pairs. </li> 
+      <li>New Line field separator (/N)</li>
      </ul> </p> </td> 
   </tr> 
   <tr> 
@@ -188,13 +189,13 @@ A typical [!UICONTROL CDF] file name contains the elements listed below. Note, *
 ### Syntax
 
 ```
-s3://aam-cdf/YOUR-S3-BUCKET-NAME/day=yyyy-mm-dd/hour=hh/AAM-CDF-PARTNER-ID-AAM PROCESS-ID_0.gz
+s3://aam-cdf/YOUR-S3-BUCKET-NAME/day=yyyy-mm-dd/hour=hh/AAM-CDF_PARTNER-ID_FILE-SEQUENCE_0.gz
 ```
 
 ### Example
 
 ```
-s3://aam-cdf/dataCompany/day=2017-09-14/hour=17/AAM_CDF_1234_000058_0.gz
+s3://aam-cdf/dataCompany/day=2017-09-14/hour=17/AAM_CDF_1234_0_0_0.gz
 ```
 
 In your [!DNL S3] storage bucket, files are sorted in ascending order by Partner ID ([!UICONTROL PID]), day, and hour.


### PR DESCRIPTION
Proposing changes to update these docs to match the current functionality. I want to add in the New line field separator (/N), as we're observing this field separator in customer CDF exports, however I'm not sure of the details of when/where this field separator is utilized. I'm also not sure if the old field separators are still in use, so I didn't make any changes there. I was able to confirm the changes to the file names from the following email communication (forwarded to me by Shane Nielson):

What's Changing?
In summary, Audience Manager is migrating the backend processing for CDF jobs to an updated infrastructure to enhance overall stability. The migration has already been tested with a subset of customers with no meaningful impact to their operations to consume and process the files. 
 
What Do Customers Need to Do?
Customers are not required to make any changes to their existing operations. An overview of potential changes in the CDF jobs that may be observed are outlined below:
 
1.	Request_parameters:
The request_params field gets encoded using java.net.URLEncoder currently but will transition to JavaScript (rather than Java). JS's encodeURIComponent is used. For example, the space character is encoded as '%20' currently but will be encoded as '+.' 
 
2.	Change in number of files being written to S3
The total number of rows will be the same but the way the data is split into files will be different and is a function of the warehouse size
 
3.	Filename format: 
AAM_CDF_<PID>_xxxxxx_x.gz will now look like AAM_CDF_<PID>_y_y_y.gz. For example, a file generated by current methods would be named as AAM_CDF_8058_000000_0.gz while a new generated file will be named as AAM_CDF_8058_7_7_0.gz.